### PR TITLE
Fix panic

### DIFF
--- a/gin/main.go
+++ b/gin/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
+	"github.com/devopsfaith/krakend/router"
 	krakendgin "github.com/devopsfaith/krakend/router/gin"
 )
 
@@ -67,6 +68,7 @@ func main() {
 		HandlerFactory: func(configuration *config.EndpointConfig, proxy proxy.Proxy) gin.HandlerFunc {
 			return cache.CachePage(store, configuration.CacheTTL, krakendgin.EndpointHandler(configuration, proxy))
 		},
+		RunServer:    router.RunServer,
 	})
 
 	routerFactory.New().Run(serviceConfig)


### PR DESCRIPTION
I have this when I trying to start the example:
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x95df69]

goroutine 1 [running]:
github.com/devopsfaith/krakend/router/gin.ginRouter.Run(0xc0002e3d40, 0xc00000ea58, 0x1, 0x1, 0xae1f98, 0xb7cac0, 0xc000326340, 0xb821e0, 0xc000201890, 0x0, ...)
	/go/pkg/mod/github.com/devopsfaith/krakend@v0.0.0-20181030151625-f82f671d8f1d/router/gin/router.go:96 +0x3c9
main.main()
```
I have added new line with RunServer param for NewFactory method. It seems to me that it should fix the problem.